### PR TITLE
fix: send up original source file in addition to bundled version

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,9 +1,18 @@
+const { readFileSync } = require('fs');
+const path = require('path');
+
 const nock = require('nock');
 
 const action = require('..');
 
-const openapiBundled = require('./__fixtures__/openapi-file-resolver-bundled.json');
-const petstore = require('./__fixtures__/petstore.json');
+const openapiBundled = readFileSync(path.join(__dirname, './__fixtures__/openapi-file-resolver-bundled.json'), 'utf8');
+const openapiFileResolver = readFileSync(path.join(__dirname, '/__fixtures__/openapi-file-resolver.json'), 'utf8');
+const petstore = readFileSync(path.join(__dirname, '/__fixtures__/petstore.json'), 'utf8');
+const petstoreYaml = readFileSync(path.join(__dirname, '/__fixtures__/petstore.yaml'), 'utf8');
+const petstoreYamlSingleQuotes = readFileSync(
+  path.join(__dirname, '/__fixtures__/petstore-single-quotes.yaml'),
+  'utf8'
+);
 
 nock.disableNetConnect();
 
@@ -27,7 +36,8 @@ test('should upload specs to micro', async () => {
         specs: [
           {
             fileName: '__tests__/__fixtures__/petstore.json',
-            oas: JSON.stringify(petstore),
+            oas: JSON.stringify(JSON.parse(petstore)),
+            original: petstore,
           },
         ],
       })
@@ -47,7 +57,8 @@ test('should work for yaml specs', async () => {
         specs: [
           {
             fileName: '__tests__/__fixtures__/petstore.yaml',
-            oas: JSON.stringify(petstore),
+            oas: JSON.stringify(JSON.parse(petstore)),
+            original: petstoreYaml,
           },
         ],
       })
@@ -67,7 +78,8 @@ test('should work for single quoted yaml specs', async () => {
         specs: [
           {
             fileName: '__tests__/__fixtures__/petstore-single-quotes.yaml',
-            oas: JSON.stringify(petstore),
+            oas: JSON.stringify(JSON.parse(petstore)),
+            original: petstoreYamlSingleQuotes,
           },
         ],
       })
@@ -87,7 +99,8 @@ test('should bundle specs with file references', async () => {
         specs: [
           {
             fileName: '__tests__/__fixtures__/openapi-file-resolver.json',
-            oas: JSON.stringify(openapiBundled),
+            oas: JSON.stringify(JSON.parse(openapiBundled)),
+            original: openapiFileResolver,
           },
         ],
       })

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,25 @@
+const { isOpenApiJson, isOpenApiYaml } = require('../utils');
+
+describe('isOpenApiJson()', () => {
+  it('should check for `openapi` property', () => {
+    expect(isOpenApiJson({ openapi: '3.0.0' })).toBe(true);
+  });
+
+  it('should check for `swagger` property', () => {
+    expect(isOpenApiJson({ swagger: '2.0.0' })).toBe(true);
+  });
+});
+
+describe('isOpenApiYaml()', () => {
+  it('should check for `openapi` property', () => {
+    expect(isOpenApiYaml('openapi: 3.0.0')).toBe(true);
+    expect(isOpenApiYaml('openapi: "3.0.0"')).toBe(true);
+    expect(isOpenApiYaml("openapi: '3.0.0'")).toBe(true);
+  });
+
+  it('should check for `swagger` property', () => {
+    expect(isOpenApiYaml('swagger: 2.0.0')).toBe(true);
+    expect(isOpenApiYaml('swagger: "2.0.0"')).toBe(true);
+    expect(isOpenApiYaml("swagger: '2.0.0'")).toBe(true);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ async function main(opts) {
     const file = path.join(process.cwd(), fileName);
     if (fs.existsSync(file)) {
       let oas = {};
+      const original = fs.readFileSync(file, 'utf-8');
       if (fileName === 'api.config.json') {
         /*
         const prepare = await import('./api.js/prepare.js');
@@ -82,6 +83,7 @@ async function main(opts) {
         fileName,
         // eslint-disable-next-line no-await-in-loop
         oas: JSON.stringify(await normalized.bundle()),
+        original,
       });
     }
   }

--- a/utils.js
+++ b/utils.js
@@ -3,27 +3,29 @@ const path = require('path');
 
 const glob = require('glob');
 
+function isOpenApiJson(json) {
+  return !!(json.openapi || json.swagger);
+}
+
+function isOpenApiYaml(yaml) {
+  // eslint-disable-next-line unicorn/no-unsafe-regex
+  return !!yaml.match(/\s?(openapi|swagger):\s([\s("|').0-9]+){3,}/);
+}
+
 function filterOas(files) {
   const oas = files.filter(fn => {
     if (fn.match(/.json$/)) {
       try {
         // eslint-disable-next-line import/no-dynamic-require, global-require
         const j = require(path.join(process.cwd(), fn));
-        if (j.openapi || j.swagger) {
-          return true;
-        }
+        return isOpenApiJson(j);
       } catch (e) {
         /* empty */
       }
     }
     if (fn.match(/.(yaml|yml)/)) {
-      // console.log('checking', path.join(process.cwd(), fn));
       const j = fs.readFileSync(path.join(process.cwd(), fn), 'utf8');
-      // eslint-disable-next-line unicorn/no-unsafe-regex
-      const match = j.match(/\s?(openapi|swagger):\s([\s("|').0-9]+){3,}/);
-      // console.log('match?', match);
-
-      if (match) return true;
+      return isOpenApiYaml(j);
     }
     return false;
   });
@@ -53,3 +55,6 @@ module.exports = {
     return out;
   },
 };
+
+module.exports.isOpenApiJson = isOpenApiJson;
+module.exports.isOpenApiYaml = isOpenApiYaml;


### PR DESCRIPTION
## 🧰 Changes

This will fix a bug currently on the OAS view page, where we're showing
a minified version of the spec file and always showing JSON regardless
of whether it was a JSON or YAML file

## 🧬 QA & Testing

Do the tests pass? ✅
