### PR TITLE
report package version in API payload (for readmeio/micro#211)

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -3,7 +3,10 @@ const path = require('path');
 
 const nock = require('nock');
 
+nock.disableNetConnect();
+
 const action = require('..');
+// const { getPkgVersion } = require('../lib/getPkgVersion');
 
 const openapiBundled = readFileSync(path.join(__dirname, './__fixtures__/openapi-file-resolver-bundled.json'), 'utf8');
 const openapiFileResolver = readFileSync(path.join(__dirname, '/__fixtures__/openapi-file-resolver.json'), 'utf8');
@@ -14,7 +17,9 @@ const petstoreYamlSingleQuotes = readFileSync(
   'utf8'
 );
 
-nock.disableNetConnect();
+const mockConfig = {
+  key: '123456',
+};
 
 /* We only want to test the oas property on the
  * body because there are a bunch of other
@@ -44,7 +49,7 @@ test('should upload specs to micro', async () => {
     )
     .reply(200);
 
-  await action({ key: '123456', src: ['__tests__/__fixtures__/petstore.json'] });
+  await action({ ...mockConfig, src: ['__tests__/__fixtures__/petstore.json'] });
   mock.done();
 });
 
@@ -65,7 +70,7 @@ test('should work for yaml specs', async () => {
     )
     .reply(200);
 
-  await action({ key: '123456', src: ['__tests__/__fixtures__/petstore.yaml'] });
+  await action({ ...mockConfig, src: ['__tests__/__fixtures__/petstore.yaml'] });
   mock.done();
 });
 
@@ -86,7 +91,7 @@ test('should work for single quoted yaml specs', async () => {
     )
     .reply(200);
 
-  await action({ key: '123456', src: ['__tests__/__fixtures__/petstore-single-quotes.yaml'] });
+  await action({ ...mockConfig, src: ['__tests__/__fixtures__/petstore-single-quotes.yaml'] });
   mock.done();
 });
 
@@ -107,7 +112,7 @@ test('should bundle specs with file references', async () => {
     )
     .reply(200, JSON.stringify({ url: 'https://example.com', explanation: 'Lorem ipsum' }));
 
-  await action({ key: '123456', src: ['__tests__/__fixtures__/openapi-file-resolver.json'] });
+  await action({ ...mockConfig, src: ['__tests__/__fixtures__/openapi-file-resolver.json'] });
   mock.done();
 });
 
@@ -117,6 +122,29 @@ test('should work with no files being present', async () => {
     .post('/api/uploadSpec', JSON.stringify({ specs: [] }))
     .reply(200);
 
-  await action({ key: '123456', src: ['__tests__/__fixtures__/non-existent-file.json'] });
+  await action({ ...mockConfig, src: ['__tests__/__fixtures__/non-existent-file.json'] });
   mock.done();
 });
+
+// function filteringRequestBodyActionVersion(body) {
+//   const { specs, actionVersion } = JSON.parse(body);
+//   return JSON.stringify({ specs, actionVersion });
+// }
+//
+// TODO: this is commented out until I can figure out this error:
+// ::error::Nock: No match for request {%0A  "method": "POST",%0A  "url": "https://micro.readme.com/api/uploadSpec",%0A  "headers": {%0A    "accept": "application/json, text/plain, */*",%0A    "content-type": "application/json",%0A    "x-api-key": "123456",%0A    "user-agent": "axios/0.27.2",%0A    "content-length": 36%0A  },%0A  "body": "{\"specs\":[],\"actionVersion\":\"2.3.0\"}"%0A}
+//
+// eslint-disable-next-line jest/no-commented-out-tests
+// test('should send action package version', async () => {
+//   const mock = nock('https://micro.readme.com')
+//     .filteringRequestBody(filteringRequestBodyActionVersion)
+//     .post('/api/uploadSpec', JSON.stringify({ specs: [], actionVersion: getPkgVersion() }))
+//     .reply(200);
+
+//   const response = await action({ ...mockConfig, src: ['__tests__/__fixtures__/non-existent-file.json'] });
+//   // mock.done();
+
+//   expect(response).resolves.toMatchObject({ specs: [], actionVersion: getPkgVersion() });
+
+//   return await mock.isDone();
+// });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,7 +6,7 @@ const nock = require('nock');
 nock.disableNetConnect();
 
 const action = require('..');
-const { getPkgVersion } = require('../lib/getPkgVersion');
+const getPkgVersion = require('../lib/getPkgVersion');
 
 const openapiBundled = readFileSync(path.join(__dirname, './__fixtures__/openapi-file-resolver-bundled.json'), 'utf8');
 const openapiFileResolver = readFileSync(path.join(__dirname, '/__fixtures__/openapi-file-resolver.json'), 'utf8');

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,7 +6,7 @@ const nock = require('nock');
 nock.disableNetConnect();
 
 const action = require('..');
-// const { getPkgVersion } = require('../lib/getPkgVersion');
+const { getPkgVersion } = require('../lib/getPkgVersion');
 
 const openapiBundled = readFileSync(path.join(__dirname, './__fixtures__/openapi-file-resolver-bundled.json'), 'utf8');
 const openapiFileResolver = readFileSync(path.join(__dirname, '/__fixtures__/openapi-file-resolver.json'), 'utf8');
@@ -126,25 +126,17 @@ test('should work with no files being present', async () => {
   mock.done();
 });
 
-// function filteringRequestBodyActionVersion(body) {
-//   const { specs, actionVersion } = JSON.parse(body);
-//   return JSON.stringify({ specs, actionVersion });
-// }
-//
-// TODO: this is commented out until I can figure out this error:
-// ::error::Nock: No match for request {%0A  "method": "POST",%0A  "url": "https://micro.readme.com/api/uploadSpec",%0A  "headers": {%0A    "accept": "application/json, text/plain, */*",%0A    "content-type": "application/json",%0A    "x-api-key": "123456",%0A    "user-agent": "axios/0.27.2",%0A    "content-length": 36%0A  },%0A  "body": "{\"specs\":[],\"actionVersion\":\"2.3.0\"}"%0A}
-//
-// eslint-disable-next-line jest/no-commented-out-tests
-// test('should send action package version', async () => {
-//   const mock = nock('https://micro.readme.com')
-//     .filteringRequestBody(filteringRequestBodyActionVersion)
-//     .post('/api/uploadSpec', JSON.stringify({ specs: [], actionVersion: getPkgVersion() }))
-//     .reply(200);
+function filteringRequestBodyActionVersion(body) {
+  const { specs, actionVersion } = JSON.parse(body);
+  return JSON.stringify({ specs, actionVersion });
+}
 
-//   const response = await action({ ...mockConfig, src: ['__tests__/__fixtures__/non-existent-file.json'] });
-//   // mock.done();
+test('should send action package version', async () => {
+  const mock = nock('https://micro.readme.com')
+    .filteringRequestBody(filteringRequestBodyActionVersion)
+    .post('/api/uploadSpec', JSON.stringify({ specs: [], actionVersion: getPkgVersion() }))
+    .reply(200);
 
-//   expect(response).resolves.toMatchObject({ specs: [], actionVersion: getPkgVersion() });
-
-//   return await mock.isDone();
-// });
+  await action({ ...mockConfig, src: ['__tests__/__fixtures__/non-existent-file.json'] });
+  mock.done();
+});

--- a/__tests__/lib/getPkgVersion.test.js
+++ b/__tests__/lib/getPkgVersion.test.js
@@ -1,6 +1,11 @@
 const getPkgVersion = require('../../lib/getPkgVersion');
 
-jest.mock('../../package.json', () => ({ version: 1.1 }), {
+const mockPkg = {
+  name: 'mock-@readme/micro',
+  version: '1.2.0',
+};
+
+jest.mock('../../package.json', () => mockPkg, {
   virtual: true, // needed to mock a JSON file
 });
 
@@ -15,14 +20,14 @@ describe('#getPkgVersion()', () => {
     // eslint-disable-next-line global-require
     const pkg = require('../../package.json');
 
-    it('should grab version', () => {
-      return expect(getPkgVersion()).toBe(String(pkg.version));
+    it('should correctly grab version', () => {
+      return expect(getPkgVersion()).toBe(pkg.version);
     });
   });
 
-  describe('from mocked package.json', () => {
-    it('should parse numeric version from package.json as string', () => {
-      return expect(getPkgVersion()).toBe('1.1');
+  describe('from mock package.json', () => {
+    it('should correctly grab version', () => {
+      return expect(getPkgVersion()).toBe(mockPkg.version);
     });
   });
 });

--- a/__tests__/lib/getPkgVersion.test.js
+++ b/__tests__/lib/getPkgVersion.test.js
@@ -1,4 +1,4 @@
-const { getPkgVersion } = require('../../lib/getPkgVersion');
+const getPkgVersion = require('../../lib/getPkgVersion');
 
 jest.mock('../../package.json', () => ({ version: 1.1 }), {
   virtual: true, // needed to mock a JSON file

--- a/__tests__/lib/getPkgVersion.test.js
+++ b/__tests__/lib/getPkgVersion.test.js
@@ -1,0 +1,28 @@
+const { getPkgVersion } = require('../../lib/getPkgVersion');
+
+jest.mock('../../package.json', () => ({ version: 1.1 }), {
+  virtual: true, // needed to mock a JSON file
+});
+
+describe('#getPkgVersion()', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  // source adapted from `rdme`:
+  // https://github.com/readmeio/rdme/blob/HEAD/__tests__/lib/getPkgVersion.test.ts
+  describe('from actual package.json', () => {
+    // eslint-disable-next-line global-require
+    const pkg = require('../../package.json');
+
+    it('should grab version', () => {
+      return expect(getPkgVersion()).toBe(String(pkg.version));
+    });
+  });
+
+  describe('from mocked package.json', () => {
+    it('should parse numeric version from package.json as string', () => {
+      return expect(getPkgVersion()).toBe('1.1');
+    });
+  });
+});

--- a/index.js
+++ b/index.js
@@ -43,10 +43,8 @@ async function main(opts) {
     markdown: undefined, // micro.md file
     specs: [], // the specs {filename, oas}
     ...context,
-    actionMeta: {
-      // version number of this package before published to GH Marketplace & npm
-      version: pkg.version,
-    },
+    // version number of this package that will be published to npm & GH Marketplace
+    actionVersion: version: pkg.version,
   };
 
   const markdown = path.join(process.cwd(), 'micro.md');

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const { default: OASNormalize } = require('oas-normalize');
 const swaggerInline = require('swagger-inline');
 
 const getContext = require('./lib/context');
-const pkg = require('./package.json');
+const { getPkgVersion } = require('./lib/getPkgVersion');
 const utils = require('./utils');
 
 require('dotenv').config({ path: path.join(__dirname, '.env') });
@@ -43,8 +43,11 @@ async function main(opts) {
     markdown: undefined, // micro.md file
     specs: [], // the specs {filename, oas}
     ...context,
-    // version number of this package that will be published to npm & GH Marketplace
-    actionVersion: version: pkg.version,
+    // this package's version number
+    actionVersion: getPkgVersion(),
+    // adapted from `rdme` Action:
+    // https://github.com/readmeio/rdme/blob/HEAD/src/lib/createGHA/index.ts#L262
+    // https://github.com/readmeio/rdme/blob/HEAD/__tests__/lib/fetch.test.ts#L30
   };
 
   const markdown = path.join(process.cwd(), 'micro.md');

--- a/index.js
+++ b/index.js
@@ -43,11 +43,7 @@ async function main(opts) {
     markdown: undefined, // micro.md file
     specs: [], // the specs {filename, oas}
     ...context,
-    // this package's version number
-    actionVersion: getPkgVersion(),
-    // adapted from `rdme` Action:
-    // https://github.com/readmeio/rdme/blob/HEAD/src/lib/createGHA/index.ts#L262
-    // https://github.com/readmeio/rdme/blob/HEAD/__tests__/lib/fetch.test.ts#L30
+    actionVersion: getPkgVersion(), // version of Micro that's running
   };
 
   const markdown = path.join(process.cwd(), 'micro.md');

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const { default: OASNormalize } = require('oas-normalize');
 const swaggerInline = require('swagger-inline');
 
 const getContext = require('./lib/context');
-const { getPkgVersion } = require('./lib/getPkgVersion');
+const getPkgVersion = require('./lib/getPkgVersion');
 const utils = require('./utils');
 
 require('dotenv').config({ path: path.join(__dirname, '.env') });

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const { default: OASNormalize } = require('oas-normalize');
 const swaggerInline = require('swagger-inline');
 
 const getContext = require('./lib/context');
+const pkg = require('./package.json');
 const utils = require('./utils');
 
 require('dotenv').config({ path: path.join(__dirname, '.env') });
@@ -42,6 +43,7 @@ async function main(opts) {
     markdown: undefined, // micro.md file
     specs: [], // the specs {filename, oas}
     ...context,
+    actionMeta: { version: pkg.version }
   };
 
   const markdown = path.join(process.cwd(), 'micro.md');

--- a/index.js
+++ b/index.js
@@ -43,7 +43,10 @@ async function main(opts) {
     markdown: undefined, // micro.md file
     specs: [], // the specs {filename, oas}
     ...context,
-    actionMeta: { version: pkg.version }
+    actionMeta: {
+      // version number of this package before published to GH Marketplace & npm
+      version: pkg.version,
+    },
   };
 
   const markdown = path.join(process.cwd(), 'micro.md');

--- a/lib/getPkgVersion.js
+++ b/lib/getPkgVersion.js
@@ -1,0 +1,15 @@
+// source adapted from `rdme`:
+// https://github.com/readmeio/rdme/blob/HEAD/src/lib/getPkgVersion.ts#L26-L47
+
+/**
+ * The current `micro` version, extracted from the `package.json`.
+ */
+function getPkgVersion() {
+  // eslint-disable-next-line global-require
+  const pkg = require('../package.json');
+  return `${pkg.version}`;
+}
+
+module.exports = getPkgVersion;
+
+module.exports.getPkgVersion = getPkgVersion;

--- a/lib/getPkgVersion.js
+++ b/lib/getPkgVersion.js
@@ -11,5 +11,3 @@ function getPkgVersion() {
 }
 
 module.exports = getPkgVersion;
-
-module.exports.getPkgVersion = getPkgVersion;


### PR DESCRIPTION
| 🚥 Related to #9 and readmeio/micro#211 |
| :---------------- |

## 🧰 Changes

Adds the version number in the payload sent during Webhook events (e.g., <kbd>push</kbd>). The Micro UI then stores that in its DB to version check sync'd repos against the latest published version.

### Additional context
The version is inferred from the `package.json` at the time of the release (`git tag && npm version && npm publish`) to the [`@readme/micro` npm package](https://www.npmjs.com/package/@readme/micro). Why?

1. [GitHub's `context`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) is inconsistent between webhook event types. `github.action_repository` (e.g., <kbd>"readmeio/readme-micro"</kbd>) and `github.action_ref` (e.g., <kbd>"refs/tags/2.3.0"</kbd>) are not guaranteed to be in the response from every webhook type.
2. Bitbucket doesn't have a similar `context`. Getting the version would require additional boilerplate code to, for example, parse the version from the args passed, `process.argv`, where `micro` is invoked in the `bitbucket-pipelines.yml` file: <kbd>script: npx @readme/micro@v2</kbd>.

## 🧬 QA & Testing

Run with debugging logs enabled. Ensure the version, without an `x`, appears as a string formatted as `[\d]+.[\d]+.[\d]+` (e.g., <kbd>"2.3.0"</kbd>).