### PR TITLE
feat: send bitbucket workspace name into the API payload

### DIFF
--- a/__tests__/lib/context.test.js
+++ b/__tests__/lib/context.test.js
@@ -79,6 +79,7 @@ describe('getContext()', () => {
       process.env.BITBUCKET_COMMIT = latestCommitSha;
       process.env.BITBUCKET_STEP_TRIGGERER_UUID = '{636fcf11-a096-4b88-99ed-ce185e001fdb}';
       process.env.BITBUCKET_BUILD_NUMBER = '1234';
+      process.env.BITBUCKET_WORKSPACE = 'workspace-name';
       process.env.BITBUCKET_REPO_SLUG = 'repo-name';
       process.env.BITBUCKET_BRANCH = 'main';
 
@@ -105,6 +106,7 @@ describe('getContext()', () => {
             },
           ],
           repository: {
+            organization: process.env.BITBUCKET_WORKSPACE,
             name: process.env.BITBUCKET_REPO_SLUG,
           },
         },

--- a/lib/context.js
+++ b/lib/context.js
@@ -62,6 +62,7 @@ module.exports = async function getContext() {
         payload: {
           repository: {
             name: process.env.BITBUCKET_REPO_SLUG,
+            organization: process.env.BITBUCKET_WORKSPACE,
           },
           commits: [
             {


### PR DESCRIPTION
## 🧰 Changes

This is required for the improved onboarding flow

Can test this on bitbucket by replacing your pipeline file with:

```yaml
#  ReadMe Micro
image: node:18

pipelines:
  default:
    - parallel:
      - step:
          name: ReadMe Micro
          script:
            - npm install "https://github.com/readmeio/readme-micro#feat/send-bitbucket-workspace-name"
            - npx @readme/micro '**/*.{yaml,yml,json}' --key=$README_MICRO_SECRET
```

## 🧬 QA & Testing

Do the tests pass? ✅
