### PR TITLE
chore(README): auto-replace major pkg version in Action code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettier:fix": "prettier --list-different --write \"./**/**.{js,md,yaml,json}\"",
     "test": "jest",
     "preversion": "echo $npm_package_version > .old-version.txt",
-    "version": "sed -i '' \"s/$(cat .old-version.txt)/$npm_package_version/\" README.md && git add README.md",
+    "version": "sed -i '' \"s#micro@[^[:space:]]+#micro@v$(cat .old-version.txt | cut -d '.' -f 1)#g\" README.md && git add README.md || true",
     "postversion": "rm -rf .old-version.txt && ./bin/set-major-version-tag.js"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "prettier --check \"./**/**.{js,md,yaml,json}\"",
     "prettier:fix": "prettier --list-different --write \"./**/**.{js,md,yaml,json}\"",
     "test": "jest",
-    "version": "sed -i '' \"s#micro@[^[:space:]]+#micro@v$(echo $npm_package_version | cut -d '.' -f 1)#g\" README.md && git add README.md || true",
+    "version": "sed -i '' -r \"s#readme-micro@v[[:digit:].]+#readme-micro@v$(echo $package_version | cut -d '.' -f 1)#\" README.md && git add README.md || true",
     "postversion": "./bin/set-major-version-tag.js"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettier:fix": "prettier --list-different --write \"./**/**.{js,md,yaml,json}\"",
     "test": "jest",
     "preversion": "echo $npm_package_version > .old-version.txt",
-    "version": "sed -i '' \"s#micro@[^[:space:]]+#micro@v$(cat .old-version.txt | cut -d '.' -f 1)#g\" README.md && git add README.md || true",
+    "version": "sed -i '' \"s#micro@[^[:space:]]+#micro@v$(echo $npm_package_version | cut -d '.' -f 1)#g\" README.md && git add README.md || true",
     "postversion": "rm -rf .old-version.txt && ./bin/set-major-version-tag.js"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "prettier": "prettier --check \"./**/**.{js,md,yaml,json}\"",
     "prettier:fix": "prettier --list-different --write \"./**/**.{js,md,yaml,json}\"",
     "test": "jest",
-    "preversion": "echo $npm_package_version > .old-version.txt",
     "version": "sed -i '' \"s#micro@[^[:space:]]+#micro@v$(echo $npm_package_version | cut -d '.' -f 1)#g\" README.md && git add README.md || true",
-    "postversion": "rm -rf .old-version.txt && ./bin/set-major-version-tag.js"
+    "postversion": "./bin/set-major-version-tag.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
| 🚥 Fixes #9, enhances #20 |
| :---------------- |

## 🧰 Changes

Changes `…micro@v30.2.1` to `…micro@v30` (semver major tag).

See PR #20 and issue #9 for context.

## 🧬 QA & Testing

Try publishing package locally with npm, but discard - do not push to the registry.